### PR TITLE
Feat/filtering component: button light gray & primary half 색 추가

### DIFF
--- a/durihana/app/globals.css
+++ b/durihana/app/globals.css
@@ -66,6 +66,7 @@
     --skyblue: #e0f0f5;
     --lime: #e1f4e2;
     --red: #ec4774;
+    --primaryhalf: #48989680;
   }
 
   @theme inline {
@@ -88,6 +89,7 @@
     --color-pink: var(--pink);
     --color-skyblue: var(--skyblue);
     --color-lime: var(--lime);
+    --color-primaryhalf: var(--primaryhalf);
   }
 }
 

--- a/durihana/app/globals.css
+++ b/durihana/app/globals.css
@@ -54,6 +54,7 @@
     --navy: #3b4156;
     --textgray: #666666;
     --buttongray: #9ca7b3;
+    --buttonlightgray: #e9eaec;
     --primarycolor: #489896;
     --secondarycolor: #5e68bd;
     --icon: #7a8da0;

--- a/durihana/app/globals.css
+++ b/durihana/app/globals.css
@@ -78,6 +78,7 @@
     --color-navy: var(--navy);
     --color-textgray: var(--textgray);
     --color-buttongray: var(--buttongray);
+    --color-buttonlightgray: var(--buttonlightgray);
     --color-icon: var(--icon);
     --color-iconselect: var(--iconselect);
     --color-mint: var(--mint);


### PR DESCRIPTION
## 🚀 Description
globals.css에 buttonlightgray 색, primaryhalf 색 추가

## 📸 Screenshot
![image](https://github.com/user-attachments/assets/08e70a87-cb1a-484a-b2c5-7a2d9a07dcac)



## 📢 Notes
primaryhalf는 피그마의 primary50 색입니다.
