### PR TITLE
[Fix/asset page] 웨딩 내역 로직 수정

### DIFF
--- a/durihana/app/asset/page.tsx
+++ b/durihana/app/asset/page.tsx
@@ -1,22 +1,21 @@
-import { AccountCard } from '@/components/account';
-import { AssetOverview } from '@/components/asset';
-import { BottomNavigation, Header } from '@/components/atoms';
-import Container from '@/components/containers/Container';
-import { MainAccount, SubAccount } from '@/types/Account';
-import { use } from 'react';
-import {
-  getAccountsByUserId,
-  getCoupleTotalBalance,
-} from '@/lib/actions/AccountActions';
-import {
-  getBucketTotalAmount,
-  getCategoryData,
-} from '@/lib/actions/AssetActions';
-import { auth } from '@/lib/auth';
+import { AccountCard } from "@/components/account";
+import { AssetOverview } from "@/components/asset";
+import { BottomNavigation, Header } from "@/components/atoms";
+import Container from "@/components/containers/Container";
+import { getAccountsByUserId, getCoupleTotalBalance } from "@/lib/actions/AccountActions";
+import { getBucketTotalAmount, getCategoryData } from "@/lib/actions/AssetActions";
+import { auth } from "@/lib/auth";
+import { MainAccount, SubAccount } from "@/types/Account";
+import { use } from "react";
+
 
 export default function Asset() {
   const session = use(auth());
   const userId = Number(session?.user?.id);
+
+  const mainUserId = session?.user?.isMain
+    ? Number(session.user.id)
+    : Number(session?.user?.partnerId);
 
   const accounts = use(getAccountsByUserId(userId));
   const main = accounts.data.find((acc) => acc.type === 0)!;
@@ -35,10 +34,9 @@ export default function Asset() {
 
   const coupleBalance = use(getCoupleTotalBalance(userId));
 
-  const data = use(getCategoryData(userId));
-  console.log("🚀 ~ Asset ~ data:", data)
+  const data = use(getCategoryData(mainUserId));
 
-  const total = use(getBucketTotalAmount(userId));
+  const total = use(getBucketTotalAmount(mainUserId));
 
   return (
     <Container

--- a/durihana/app/asset/page.tsx
+++ b/durihana/app/asset/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/lib/actions/AccountActions';
 import {
   getBucketTotalAmount,
-  getTypeAmounts,
+  getCategoryData,
 } from '@/lib/actions/AssetActions';
 import { auth } from '@/lib/auth';
 
@@ -35,7 +35,8 @@ export default function Asset() {
 
   const coupleBalance = use(getCoupleTotalBalance(userId));
 
-  const data = use(getTypeAmounts(userId));
+  const data = use(getCategoryData(userId));
+  console.log("🚀 ~ Asset ~ data:", data)
 
   const total = use(getBucketTotalAmount(userId));
 

--- a/durihana/components/asset/AssetChart.tsx
+++ b/durihana/components/asset/AssetChart.tsx
@@ -3,9 +3,10 @@
 import { PieChart, Pie, Cell } from 'recharts';
 import Image from 'next/image';
 import Txt from '../atoms/Txt';
+import { CategoryData } from '@/types/Asset';
 
 type Props = {
-  data: { name: string; value: number }[];
+  data: CategoryData[];
 };
 
 type PieLabelProps = {

--- a/durihana/components/asset/AssetLog.tsx
+++ b/durihana/components/asset/AssetLog.tsx
@@ -3,9 +3,10 @@
 import { useRouter } from 'next/navigation';
 import { Button } from '../atoms';
 import Txt from '../atoms/Txt';
+import { CategoryData } from '@/types/Asset';
 
 type Props = {
-  data: { name: string; value: number }[];
+  data: CategoryData[];
 };
 
 export default function AssetLog({ data }: Props) {

--- a/durihana/components/asset/AssetOverview.tsx
+++ b/durihana/components/asset/AssetOverview.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { AssetLog, ProgressBar } from '@/components/asset';
+import { CategoryData } from '@/types/Asset';
 import dynamic from 'next/dynamic';
 
 type Props = {
-  data: { name: string; value: number }[];
+  data: CategoryData[];
   balance: number;
 };
 export default function AssetOverview({ data, balance }: Props) {

--- a/durihana/types/Asset.ts
+++ b/durihana/types/Asset.ts
@@ -1,0 +1,4 @@
+export type CategoryData = {
+    name: string; 
+    value: number
+};


### PR DESCRIPTION
## 🚀 Description
1. 같은 카테고리에 여러 데이터 있을 시, 하나의 카테고리고 처리되도록 수정
- 예식장, 스드메, 신혼여행: 가장 비싼 항목만 집계
- 가전가구, 예물예단: 모든 데이터 가격 합산 
2. 웨딩 카테고리별 지출, 파이차트, 프로그래스바: 메인 유저 따라가도록 수정

## 📸 Screenshot
![image](https://github.com/user-attachments/assets/0acfcb34-bb65-4e85-b2e8-3534e913e739)



## 📢 Notes

