### PR TITLE
fix: 예약 및 결제 내역 없을 시 지출 내역 시각화 수정

### DIFF
--- a/durihana/app/asset/page.tsx
+++ b/durihana/app/asset/page.tsx
@@ -45,7 +45,7 @@ export default function Asset() {
   const categoryData =
     categoryDataResult?.isSuccess && categoryDataResult.data
       ? categoryDataResult.data
-      : [{ category: '', value: 0 }];
+      : [];
 
   const total = use(getBucketTotalAmount(mainUserId));
 

--- a/durihana/app/page.tsx
+++ b/durihana/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
   const categoryData =
     categoryDataResult?.isSuccess && categoryDataResult.data
       ? categoryDataResult.data
-      : [{ category: '', value: 0 }];
+      : [];
 
   return (
     <Container


### PR DESCRIPTION
## 🚀 Description
예약 및 결제 내역이 없어 partner_calendar에 없을 경우, 빈 배열 리턴하도록 수정

## 📸 Screenshot
<!-- 작업한 화면 -->

## 📢 Notes
<!-- 리뷰 할 팀원이 참고 해야할 사항이 있다면 적어주세요! -->
